### PR TITLE
Add a --logtail option so that the user can specify a location for logtail other than /usr/sbin/logtail2

### DIFF
--- a/logster
+++ b/logster
@@ -69,6 +69,8 @@ script_start_time = time()
 # Command-line options and parsing.
 cmdline = optparse.OptionParser(usage="usage: %prog [options] parser logfile",
     description="Tail a log file and filter each line to generate metrics that can be sent to common monitoring packages.")
+cmdline.add_option('--logtail', action='store', default=logtail,
+                    help='Specify location of logtail.  Default %s' % logtail)
 cmdline.add_option('--metric-prefix', '-p', action='store',
                     help='Add prefix to all published metrics. This is for people that may multiple instances of same service on same host.',
                     default='')
@@ -108,6 +110,7 @@ if 'graphite' in options.output and not options.graphite_host:
 class_name = arguments[0]
 log_file   = arguments[1]
 state_dir  = options.state_dir
+logtail    = options.logtail
 
 
 # Logging infrastructure for use throughout the script.


### PR DESCRIPTION
Used like follows:

```
logster --logtail=/usr/local/sbin/logtail2 ...
```

Help message:

```
$ logster --help | grep --after=1 -- '--logtail'
  --logtail=LOGTAIL     Specify location of logtail.  Default
                        /usr/sbin/logtail2
```
