### PR TITLE
MetricLogster recognises difference between counters and times

### DIFF
--- a/parsers/MetricLogster.py
+++ b/parsers/MetricLogster.py
@@ -75,7 +75,7 @@ class MetricLogster(LogsterParser):
             countbits = count_match.groupdict()
             count_name = countbits['count_name']
             if not self.counts.has_key(count_name):
-                self.counts[count_name] = 0
+                self.counts[count_name] = 0.0
             self.counts[count_name] += float(countbits['count_value']);
         
         time_match = self.time_reg.match(line)

--- a/parsers/stats_helper.py
+++ b/parsers/stats_helper.py
@@ -4,23 +4,26 @@
 ###  
 ###  Percentiles are calculated with linear interpolation between points.
 
-def find_median(int_list):
-    return find_percentile(int_list,50)
+def find_median(numbers):
+    return find_percentile(numbers,50)
 
 
-def find_percentile(int_list,percentile):
-    int_list.sort()
-    if len(int_list) == 0:
+def find_percentile(numbers,percentile):
+    numbers.sort()
+    if len(numbers) == 0:
         return None
-    if len(int_list) == 1:
-        return int_list[0];
-    elif len(int_list) % 10 != 1:
-        left_index = percentile * (len(int_list) - 1) / 100
-        number_one = int_list[left_index ]
-        number_two = int_list[left_index + 1]
-        return number_one + ( number_two - number_one) * (((float(percentile)/100)*(len(int_list)-1)%1))
+    if len(numbers) == 1:
+        return numbers[0];
+    elif (float(percentile) / float(100))*float(len(numbers)-1) %1 != 0:
+        left_index = percentile * (len(numbers) - 1) / 100
+        number_one = numbers[left_index ]
+        number_two = numbers[left_index + 1]
+        return number_one + ( number_two - number_one) * (((float(percentile)/100)*(len(numbers)-1)%1))
     else:
-        return int_list[percentile*len(int_list)/100]
+        return numbers[percentile*(len(numbers)-1)/100]
 
-def find_mean(number_list):
-    return None if len(number_list) == 0 else sum(number_list,0.0) / len(number_list)
+def find_mean(numbers):
+    if len(numbers) == 0:
+        return None 
+    else:
+        return sum(numbers,0.0) / len(numbers)

--- a/parsers/test_stats_helper.py
+++ b/parsers/test_stats_helper.py
@@ -1,0 +1,65 @@
+import stats_helper
+import unittest
+
+class TestStatsHelper(unittest.TestCase):
+    
+    def test_median_of_1(self):
+        self.assertEqual(stats_helper.find_median([0]), 0)
+        self.assertEqual(stats_helper.find_median([1]), 1)
+        self.assertEqual(stats_helper.find_median([1,2]), 1.5)
+        self.assertEqual(stats_helper.find_median([1,2,3]), 2)
+        self.assertEqual(stats_helper.find_median([1,-1]), 0)
+        self.assertEqual(stats_helper.find_median([1,999999]), 500000)
+    
+    def test_median_floats(self):
+        self.assertEqual(stats_helper.find_median([float(1.1),float(2.3),float(0.4)]), 1.1)
+        
+    def test_max_0(self):
+        self.assertEqual(stats_helper.find_percentile([0],100), 0)
+    def test_max_0_to_1(self):
+        self.assertEqual(stats_helper.find_percentile([0,1],100), 1)
+    def test_max_0_to_3(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3],100), 3)
+    def test_max_0_to_5(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5],100), 5)
+    def test_max_0_to_6(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5,6],100), 6)
+    def test_max_0_to_10(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5,6,7,8,9,10],100), 10)
+    def test_max_0_to_11(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5,6,7,8,9,10,11],100), 11)
+    def test_max_floats(self):
+        self.assertEqual(stats_helper.find_percentile([0,0.1,1.5,100],100), 100)
+        
+    def test_10th_0_to_10(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5,6,7,8,9,10],10), 1)
+    
+    def test_10th_1_to_3(self):
+        self.assertEqual(stats_helper.find_percentile([1,2,3],10), 1.2)
+        
+    def test_12th_0_to_9(self):
+        self.assertEqual(stats_helper.find_percentile([0,1,2,3,4,5,6,7,8,9],12), 1.08)
+        
+    def test_90th_0(self):
+        self.assertEqual(stats_helper.find_percentile([0],90), 0)
+    
+    def test_90th_1(self):
+        self.assertEqual(stats_helper.find_percentile([1],90), 1)
+    
+    def test_90th_1_2(self):
+        self.assertEqual(stats_helper.find_percentile([1,2],90), 1.9)
+    
+    def test_90th_1_2_3(self):
+        self.assertEqual(stats_helper.find_percentile([1,2,3],90), 2.8)
+    
+    def test_90th_1_minus1(self):
+        self.assertEqual(stats_helper.find_percentile([1,-1],90), 0.8)
+    
+    def test_90th_1_to_10(self):
+        self.assertEqual(stats_helper.find_percentile([1,2,3,4,5,6,7,8,9,10],90), 9.1)
+    
+    def test_90th_1_to_11(self):
+        self.assertEqual(stats_helper.find_percentile([1,2,3,4,5,6,7,8,9,10,11],90), 10)
+    
+    def test_90th_1_to_15_noncontiguous(self):
+        self.assertAlmostEqual(stats_helper.find_percentile([1,2,3,4,5,6,7,8,9,15],90), 9.6)


### PR DESCRIPTION
Jeff and I have been in discussion over improving the MetricLogster to support parsing of arbitrary counter and time like metrics. In the same way that StatsD performs aggregation over time metrics, the MetricLogster now records the mean, median and 90th percentile for time metrics, although other percentiles can be recorded using parser options. I have contributed code to calculate these aggregates without introducing a library dependency.

Time units are extracted to support those using a Ganglia front end.

Examples of conforming log lines now:

... METRIC_TIME metric=some.metric.time value=10ms
... METRIC_TIME metric=some.metric.time value=11ms
... METRIC_TIME metric=some.metric.time value=20ms
... METRIC_COUNT metric=some.metric.count value=1
... METRIC_COUNT metric=some.metric.count value=2.2
