### PR TITLE
adding logster/parsers to be packaged with the egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ setup(
     description='Parse log files, generate metrics for Graphite and Ganglia',
     author='Etsy',
     url='https://github.com/etsy/logster',
-    packages=['logster'],
+    packages=[
+        'logster',
+        'logster/parsers'
+    ],
     zip_safe=False,
     scripts=[
         'bin/logster'


### PR DESCRIPTION
Adding logster/parsers/\* to setup.py so they get built into the egg for installing.
