### PR TITLE
ignoring build and dist folders produced during build/install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.state
 *.egg-info
 *.venv
+build
+dist


### PR DESCRIPTION
Running `python setup.py build/install` will produce build/dist folders that should be ignored by git.
