### PR TITLE
Option stdout separator

### DIFF
--- a/bin/logster
+++ b/bin/logster
@@ -90,7 +90,7 @@ cmdline.add_option('--state-dir', '-s', action='store', default=state_dir,
 cmdline.add_option('--output', '-o', action='append',
                    choices=('graphite', 'ganglia', 'stdout'),
                    help="Where to send metrics (can specify multiple times). Choices are 'graphite', 'ganglia', or 'stdout'.")
-cmdline.add_option('--stdout-seperator', action='store', default="_", dest="stdout_seperator",
+cmdline.add_option('--stdout-separator', action='store', default="_", dest="stdout_separator",
                     help='Seperator between prefix/suffix and name for stdout. Default is \"%default\".')
 cmdline.add_option('--dry-run', '-d', action='store_true', default=False,
                     help='Parse the log file but send stats to standard output.')
@@ -155,9 +155,9 @@ def submit_stats(parser, duration, options):
 def submit_stdout(metrics, options):
     for metric in metrics:
         if (options.metric_prefix != ""):
-            metric.name = options.metric_prefix + options.stdout_seperator + metric.name
+            metric.name = options.metric_prefix + options.stdout_separator + metric.name
         if (options.metric_suffix is not None):
-            metric.name = metric.name + options.stdout_seperator + options.metric_suffix
+            metric.name = metric.name + options.stdout_separator + options.metric_suffix
         print "%s %s" %(metric.name, metric.value)
 
 def submit_ganglia(metrics, options):


### PR DESCRIPTION
I've started to schedule logster under diamond (https://github.com/BrightcoveOS/Diamond). This lets me use the handlers in diamond to submit metrics from logster together with the metrics collected by diamond, using handlers such as GraphitePickleHandler, AMQP, etc.
Only issue I've got is that in the stdout output, logster hard codes underscore as a separator. Since that's often used a replacement for characters that might interfere with graphite like slashes and the like, it's difficult to later change the separator in the right places to a period in a consistent manner. This patch adds an option to replace the separator, making the post-processing unnecessary.
