### PR TITLE
Remove broken Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-install:
-	/bin/mkdir -p /usr/share/logster
-	/bin/mkdir -p /var/log/logster
-	/usr/bin/install -m 0755 -t /usr/sbin bin/logster
-	/usr/bin/install -m 0644 -t /usr/share/logster logster/logster_helper.py
-	/usr/bin/install -m 0644 -t /usr/share/logster logster/parsers/*


### PR DESCRIPTION
I believe the Makefile in its current form is broken and should be removed.
1. The Makefile uses hard-coded paths rather than standard conventions like prefixing paths with `$(DESTDIR)`, which allows for packaging by easily altering the installation directory.
2. The Makefile is incomplete and does not include additional targets beyond a rudimentary install target; so uninstalling is more difficult than it should be.
3. The logster binary is installed under _/usr/sbin_, which is inconsistent with the `setup.py` installation putting it under _/usr/bin_.
4. Installing `logster_helper.py` and the parsers under _/usr/share/logster_ does not mean they'll be in your Python path.
5. There's no need to create the _/var/log/logster_ directory, as it is handled by the main binary.

The Makefile could be fixed, but it's probably better to just use `setup.py` or packages.
