### PR TITLE
Fix ErrorLog and Squid parsers

### DIFF
--- a/logster/parsers/ErrorLogLogster.py
+++ b/logster/parsers/ErrorLogLogster.py
@@ -9,8 +9,8 @@
 import time
 import re
 
-from logster_helper import MetricObject, LogsterParser
-from logster_helper import LogsterParsingException
+from logster.logster_helper import MetricObject, LogsterParser
+from logster.logster_helper import LogsterParsingException
 
 class ErrorLogLogster(LogsterParser):
 

--- a/logster/parsers/SquidLogster.py
+++ b/logster/parsers/SquidLogster.py
@@ -26,8 +26,8 @@
 import time
 import re
 
-from logster_helper import MetricObject, LogsterParser
-from logster_helper import LogsterParsingException
+from logster.logster_helper import MetricObject, LogsterParser
+from logster.logster_helper import LogsterParsingException
 
 class SquidLogster(LogsterParser):
 


### PR DESCRIPTION
The ErrorLog and Squid parsers can't find logster_helper, so they just exit with an error:

```
Traceback (most recent call last):
  File "/usr/bin/logster", line 340, in ?
    main()
  File "/usr/bin/logster", line 255, in main
    module = __import__('logster.parsers.' + class_name, globals(), locals(), [class_name])
  File "/usr/lib/python2.4/site-packages/logster/parsers/ErrorLogLogster.py", line 12, in ?
    from logster_helper import MetricObject, LogsterParser
ImportError: No module named logster_helper
```

Included commit fixes both parsers.
