### PR TITLE
Adding timestamp to stdout output

### DIFF
--- a/bin/logster
+++ b/bin/logster
@@ -158,7 +158,7 @@ def submit_stdout(metrics, options):
             metric.name = options.metric_prefix + options.stdout_separator + metric.name
         if (options.metric_suffix is not None):
             metric.name = metric.name + options.stdout_separator + options.metric_suffix
-        print "%s %s" %(metric.name, metric.value)
+        print "%s %s %s" %(metric.timestamp, metric.name, metric.value)
 
 def submit_ganglia(metrics, options):
     for metric in metrics:


### PR DESCRIPTION
Adds the timestamp to the beginning of the output string returned by logster. Allows for integration from other tools to call logster and grab data to send to graphite. 
