### PR TITLE
Graphite socket bug -- send() vs sendall()

### DIFF
--- a/bin/logster
+++ b/bin/logster
@@ -196,23 +196,24 @@ def submit_graphite(metrics, options):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((host[0], int(host[1])))
 
-    for metric in metrics:
-
-        if (options.metric_prefix != ""):
-            metric.name = options.metric_prefix + "." + metric.name
-        if (options.metric_suffix is not None):
-            metric.name = metric.name + "." + options.metric_suffix
-
-        metric_string = "%s %s %s" % (metric.name, metric.value, metric.timestamp)
-        logger.debug("Submitting Graphite metric: %s" % metric_string)
-
+    try:
+        for metric in metrics:
+    
+            if (options.metric_prefix != ""):
+                metric.name = options.metric_prefix + "." + metric.name
+            if (options.metric_suffix is not None):
+                metric.name = metric.name + "." + options.metric_suffix
+    
+            metric_string = "%s %s %s" % (metric.name, metric.value, metric.timestamp)
+            logger.debug("Submitting Graphite metric: %s" % metric_string)
+    
+            if (not options.dry_run):
+                s.sendall("%s\n" % metric_string)
+            else:
+                print "%s %s" % (options.graphite_host, metric_string)
+    finally:
         if (not options.dry_run):
-            s.sendall("%s\n" % metric_string)
-        else:
-            print "%s %s" % (options.graphite_host, metric_string)
-
-    if (not options.dry_run):
-        s.close()
+            s.close()
 
 def submit_cloudwatch(metrics, options):
     for metric in metrics:


### PR DESCRIPTION
Use `socket.sendall()` instead of `socket.send()`, which sometimes truncates messages and causes weird intermittent failure. Also adds a try/finally block to make sure that the socket gets closed.
