### PR TITLE
Add 'null' output which can be used to not send metrics

### DIFF
--- a/bin/logster
+++ b/bin/logster
@@ -98,8 +98,8 @@ cmdline.add_option('--nsca-service-hostname', action='store',
 cmdline.add_option('--state-dir', '-s', action='store', default=state_dir,
                     help='Where to store the logtail state file.  Default location %s' % state_dir)
 cmdline.add_option('--output', '-o', action='append',
-                   choices=('graphite', 'ganglia', 'stdout', 'cloudwatch', 'nsca'),
-                   help="Where to send metrics (can specify multiple times). Choices are 'graphite', 'ganglia', 'cloudwatch', 'nsca' or 'stdout'.")
+                   choices=('graphite', 'ganglia', 'stdout', 'cloudwatch', 'nsca', 'null'),
+                   help="Where to send metrics (can specify multiple times). Choices are 'graphite', 'ganglia', 'cloudwatch', 'nsca', 'stdout' or 'null' (don't send metrics).")
 cmdline.add_option('--stdout-separator', action='store', default="_", dest="stdout_separator",
                     help='Seperator between prefix/suffix and name for stdout. Default is \"%default\".')
 cmdline.add_option('--dry-run', '-d', action='store_true', default=False,
@@ -387,7 +387,8 @@ def main():
                 # aren't any at the moment).
                 logger.debug("Parsing exception caught at %s: %s" % (lineno(), e))
 
-        submit_stats(parser, duration, options)
+        if 'null' not in options.output:
+            submit_stats(parser, duration, options)
 
     except Exception, e:
         print "Exception caught at %s: %s" % (lineno(), e)


### PR DESCRIPTION
This output can be helpful when we want to use logster to just parse lines
in a log and act upon them in some way. This way, `get_state` function becomes
optional so there isn't a need to implement it which returns a `MetricObject`.

I'm not sure if it goes against the philosophy of logster as it's essentially for sending metrics but I needed something like logster which doesn't send metrics but act upon the log lines and does something. If there is a output present like `null`which doesn't call `submit_stats` function, that would be awesome. It just increases flexibility to the cases in which I can use logster.

May be, it's a bad idea, please feel free to close the PR if it seems bizarre.
