### PR TITLE
Adding JsonLogster parser.

### DIFF
--- a/logster/parsers/JsonLogster.py
+++ b/logster/parsers/JsonLogster.py
@@ -1,0 +1,109 @@
+###  JsonLogster parses a file of JsonObjects, each on their own line.
+###  The object will be traversed, and each leaf node of the object will
+###  be keyed by a concatenated key made up of all parent keys.
+###
+###  For example:
+###  sudo ./logster --dry-run --output=ganglia --parser-options '--key-separator _' JsonLogster /var/cache/stats.log.json
+###
+import json
+import optparse
+
+from logster.logster_helper import MetricObject, LogsterParser
+from logster.logster_helper import LogsterParsingException
+
+class JsonLogster(LogsterParser):
+    '''
+    JsonLogster parses a file of JsonObjects, each on their own line.
+    The object will be traversed, and each leaf node of the object will
+    be keyed by a concatenated key made up of all parent keys.
+    You can subclass this class and implement the key_filter method
+    to skip or transform specific keys in the object hierarchy.
+    '''
+
+    def __init__(self, option_string=None):
+        '''Initialize any data structures or variables needed for keeping track
+        of the tasty bits we find in the log we are parsing.'''
+        self.metrics = {}
+
+        if option_string:
+            options = option_string.split(' ')
+        else:
+            options = []
+
+        optparser = optparse.OptionParser()
+        optparser.add_option('--key-separator', '-k', dest='key_separator', default='.',
+        help='Key separator for flattened json object key name. Default: \'.\'')
+
+        opts, args = optparser.parse_args(args=options)
+        self.key_separator = opts.key_separator
+
+    def key_filter(self, key):
+        '''
+        Default key_filter method.  Override and implement
+        this method if you want to do any filtering or transforming
+        on specific keys in your JSON object.
+        '''
+        return key
+
+    def flatten_object(self, node, separator='.', key_filter_callback=None, parent_keys=[]):
+        """
+        Recurses through dicts and/or lists and flattens them
+        into a single level dict of key: value pairs.  Each
+        key consists of all of the recursed keys joined by
+        separator.  If key_filter_callback is callable,
+        it will be called with each key.  It should return
+        either a new key which will be used in the final full
+        key string, or False, which will indicate that this
+        key and its value should be skipped.
+        """
+        items = {}
+
+        try:
+            iterator = node.iteritems()
+        except AttributeError:
+            iterator = enumerate(node)
+
+        for key, item in iterator:
+            # If key_filter_callback was provided,
+            # then call it on the key.  If the returned
+            # key is false, then, we know to skip it.
+            if callable(key_filter_callback):
+                key = key_filter_callback(key)
+            if key is False:
+                continue;
+
+            if hasattr(item, '__iter__'):
+                # merge the items all together
+                items.update(self.flatten_object(item, separator, key_filter_callback, parent_keys + [str(key)]))
+            else:
+                final_key = separator.join(parent_keys + [str(key)])
+                items[final_key] = item
+
+        return items
+
+    def parse_line(self, line):
+        '''This function should digest the contents of one line at a time, updating
+        object's state variables. Takes a single argument, the line to be parsed.'''
+
+        json_data = json.loads(line)
+        self.metrics = self.flatten_object(json.loads(line), self.key_separator, self.key_filter)
+
+    def get_state(self, duration):
+        '''Run any necessary calculations on the data collected from the logs
+        and return a list of metric objects.'''
+        self.duration = duration
+
+        metric_objects = []
+        for metric_name, metric_value in self.metrics.items():
+            if type(metric_value) == float:
+                metric_type = 'float'
+            elif type(metric_value)  == int or type(metric_value) == long:
+                metric_type = 'int32'
+            else:
+                metric_type = 'string'
+                metric_value = str(metric_value)
+
+            metric_objects.append(MetricObject(metric_name, metric_value, type='int'))
+
+        return metric_objects
+

--- a/tests/test_JsonLogster.py
+++ b/tests/test_JsonLogster.py
@@ -1,0 +1,44 @@
+from logster.parsers.JsonLogster import JsonLogster
+import unittest
+
+class TestJsonLogster(unittest.TestCase):
+    def setUp(self):
+        self.json_line = '{     "1.1": {         "value1": 0,         "value2": "hi",         "1.2": {             "value3": 0.1,             "value4": false         }     },     "2.1": ["a","b"] }'
+        self.json_data = {
+            '1.1': {
+                'value1': 0,
+                'value2': 'hi',
+                '1.2': {
+                    'value3': 0.1,
+                    'value4': False,
+                }
+            },
+            '2.1': ['a','b'],
+        }
+        self.key_separator = '&'
+        self.flattened_should_be = {
+            '1.1&value1': 0,
+            '1.1&valuetwo': 'hi',
+            '1.1&1.2&value3': 0.1,
+            '1.1&1.2&value4': False,
+            '2.1&0': 'a',
+            '2.1&1': 'b',
+        }
+
+        self.json_logster = JsonLogster('--key-separator ' + self.key_separator)
+
+    def key_filter_callback(self, key):
+        if key == 'value2':
+            key = 'valuetwo'
+
+        return key
+
+    def test_init(self):
+        self.assertEquals(self.json_logster.key_separator, self.key_separator)
+
+    def test_flatten_object(self):
+        flattened = self.json_logster.flatten_object(self.json_data, self.key_separator, self.key_filter_callback)
+        self.assertEquals(flattened, self.flattened_should_be)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This can be used to parse log files in which there is one json object per line.
Each json object will be flattened into metrics keyed by the concatenated
keys in the original json object.

I'm writing this for the Wikimedia Foundation.  We are starting to use Kafka to collect web access logs from varnish, using a varnishkafka module.  varnishkafka outputs periodic JSON stats to a file, and I'd like to use Logster to send them to Ganglia or whatever.

Here's an example subclass of JsonLogster:
https://gist.github.com/ottomata/7663920