### PR TITLE
Fix percentage calculation.

### DIFF
--- a/logster/parsers/PostfixLogster.py
+++ b/logster/parsers/PostfixLogster.py
@@ -76,9 +76,9 @@ class PostfixLogster(LogsterParser):
 
         #mind divide by zero situations 
         if (totalTxns > 0):
-           pctDeferred = (self.numDeferred / totalTxns) * 100
-           pctSent = (self.numSent / totalTxns) * 100
-           pctBounced = (self.numBounced / totalTxns ) * 100
+           pctDeferred = (float(self.numDeferred) / totalTxns) * 100
+           pctSent = (float(self.numSent) / totalTxns) * 100
+           pctBounced = (float(self.numBounced) / totalTxns ) * 100
 
         if (self.numSent > 0):
            avgDelay = self.totalDelay / self.numSent


### PR DESCRIPTION
Hi,
I fixed the percentage calculation. The old version calculated only 0 or 100 on Python 2.6.6 / 2.7.5+ due to integer division. If you cast one Integer to float, the calculation will be correct.
