### PR TITLE
#89 Fix typo: SyntaxError: invalid syntax

### DIFF
--- a/bin/logster
+++ b/bin/logster
@@ -167,7 +167,7 @@ hdlr.setFormatter(formatter)
 logger.addHandler(hdlr)
 logger.setLevel(logging.INFO)
 
-if (options.log_conf)
+if (options.log_conf):
      logging.config.fileConfig(options.log_conf)
 
 if (options.debug):


### PR DESCRIPTION
For issue #89 