### PR TITLE
add error when MetricObject name contains a space for Graphite output…

### DIFF
--- a/logster/outputs/graphite.py
+++ b/logster/outputs/graphite.py
@@ -48,6 +48,7 @@ class GraphiteOutput(LogsterOutput):
                 # Spaces in graphite metric names will cause failure
                 if ' ' in metric_name:
                     self.logger.error('Invalid metric name, spaces not allowed')
+                    return
 
                 metric_string = "%s %s %s" % (metric_name, metric.value, metric.timestamp)
                 self.logger.debug("Submitting Graphite metric: %s" % metric_string)

--- a/logster/outputs/graphite.py
+++ b/logster/outputs/graphite.py
@@ -45,6 +45,10 @@ class GraphiteOutput(LogsterOutput):
             for metric in metrics:
                 metric_name = self.get_metric_name(metric)
 
+                # Spaces in graphite metric names will cause failure
+                if ' ' in metric_name:
+                    self.logger.error('Invalid metric name, spaces not allowed')
+
                 metric_string = "%s %s %s" % (metric_name, metric.value, metric.timestamp)
                 self.logger.debug("Submitting Graphite metric: %s" % metric_string)
 


### PR DESCRIPTION
…s, it causes a silent failure
