### PR TITLE
Reduce DNS lookups for the statsd domain

### DIFF
--- a/logster/outputs/statsd.py
+++ b/logster/outputs/statsd.py
@@ -23,6 +23,7 @@ class StatsdOutput(LogsterOutput):
     def submit(self, metrics):
         if (not self.dry_run):
             host = self.statsd_host.split(':')
+            host[0] = socket.gethostbyname(host[0])
 
         for metric in metrics:
             metric_name = self.get_metric_name(metric)


### PR DESCRIPTION
The sendto socket call is very flexible but it currently
issue a DNS lookup for the statsd domain for every
metric in the for loop to push. This change ensures that
only one lookup is performed for each batch of metrics
to send. It is particularly useful when logster runs
every minute and the number of metrics to push is very high.

Issue: https://github.com/etsy/logster/issues/103