### PR TITLE
Don't parse twice each JSON input line

### DIFF
--- a/logster/parsers/JsonLogster.py
+++ b/logster/parsers/JsonLogster.py
@@ -93,7 +93,7 @@ class JsonLogster(LogsterParser):
             json_data = json.loads(line)
         except Exception as e:
             raise LogsterParsingException("{0} - {1}".format(type(e), e))
-        self.metrics = self.flatten_object(json.loads(line), self.key_separator, self.key_filter)
+        self.metrics = self.flatten_object(json_data, self.key_separator, self.key_filter)
 
     def get_state(self, duration):
         '''Run any necessary calculations on the data collected from the logs


### PR DESCRIPTION
In `parse_line` the JSON contents are parsed already inside the `try` statement and assigned to `json_data`. We can reuse the
contents of the variable and voiding parsing the JSON a second time.